### PR TITLE
Fix division by 0 crash

### DIFF
--- a/dialogs/display-settings/main.c
+++ b/dialogs/display-settings/main.c
@@ -2302,11 +2302,8 @@ lay_out_outputs_horizontally (void)
         output = list->data;
         if (output->connected && output->on)
         {
-            if ((gint)output->x + (gint)output->width > x || output->y > y)
-            {
-                y = output->y;
-                x = output->x + output->width;
-            }
+            y = MAX(output->y, y);
+            x = MAX(output->x + output->width, x);
         }
     }
 


### PR DESCRIPTION
I'm not sure why gdk_screen_height_mm() was 0 in the first place, but it crashed on my PC because of this.