### PR TITLE
Fixed syndaemon not starting

### DIFF
--- a/xfsettingsd/pointers.c
+++ b/xfsettingsd/pointers.c
@@ -39,6 +39,7 @@
 #include <gdk/gdkx.h>
 #include <xfconf/xfconf.h>
 #include <libxfce4util/libxfce4util.h>
+#include <locale.h>
 
 #include <dbus/dbus-glib.h>
 
@@ -350,6 +351,7 @@ xfce_pointers_helper_syndaemon_check (XfcePointersHelper *helper)
         disable_duration = xfconf_channel_get_double (helper->channel,
                                                       "/DisableTouchpadDuration",
                                                       2.0);
+        setlocale(LC_NUMERIC, "C"); /* syndaemon needs a dot for the float. Nothing localized! */
         g_snprintf (disable_duration_string, sizeof (disable_duration_string),
                     "%.1f", disable_duration);
 


### PR DESCRIPTION
Fixed syndaemon not starting if the current locale creates a colon in the float-number for syndaemon.

I'm pretty sure that the include shall not be just there (but rather in some distro specific ifdef) and setting the locale without resetting to the original value just before using is probably also not ideal but it resolves the problem and someone with a deeper knowhow where to put this command might give me a hint - thanks!