### PR TITLE
Add a --disable-wm-check flag like that of xfdesktop and xfce4-panel

### DIFF
--- a/xfsettingsd/main.c
+++ b/xfsettingsd/main.c
@@ -75,6 +75,7 @@
 
 static gboolean opt_version = FALSE;
 static gboolean opt_no_daemon = FALSE;
+static gboolean opt_disable_wm_check = FALSE;
 static gboolean opt_replace = FALSE;
 static guint owner_id;
 
@@ -100,6 +101,7 @@ static GOptionEntry option_entries[] =
 {
     { "version", 'V', 0, G_OPTION_ARG_NONE, &opt_version, N_("Version information"), NULL },
     { "no-daemon", 0, 0, G_OPTION_ARG_NONE, &opt_no_daemon, N_("Do not fork to the background"), NULL },
+    { "disable-wm-check", 'D', 0, G_OPTION_ARG_NONE, &opt_disable_wm_check, N_("Do not wait for a window manager on startup"), NULL },
     { "replace", 0, 0, G_OPTION_ARG_NONE, &opt_replace, N_("Replace running xsettings daemon (if any)"), NULL },
     { NULL }
 };
@@ -139,6 +141,10 @@ on_name_acquired (GDBusConnection *connection,
     s_data->accessibility_helper = g_object_new (XFCE_TYPE_ACCESSIBILITY_HELPER, NULL);
     s_data->shortcuts_helper = g_object_new (XFCE_TYPE_KEYBOARD_SHORTCUTS_HELPER, NULL);
     s_data->keyboard_layout_helper = g_object_new (XFCE_TYPE_KEYBOARD_LAYOUT_HELPER, NULL);
+    if (opt_disable_wm_check)
+    {
+      xfce_workspaces_helper_disable_wm_check();
+    }
     s_data->workspaces_helper = g_object_new (XFCE_TYPE_WORKSPACES_HELPER, NULL);
     s_data->gtk_decorations_helper = g_object_new (XFCE_TYPE_DECORATIONS_HELPER, NULL);
 

--- a/xfsettingsd/workspaces.c
+++ b/xfsettingsd/workspaces.c
@@ -76,7 +76,7 @@ struct _XfceWorkspacesHelperClass
     GObjectClass parent;
 };
 
-
+static gboolean global_disable_wm_check = FALSE;
 
 #ifdef GDK_WINDOWING_X11
 static Atom atom_net_number_of_desktops = 0;
@@ -99,7 +99,11 @@ WaitForWM;
 
 G_DEFINE_TYPE(XfceWorkspacesHelper, xfce_workspaces_helper, G_TYPE_OBJECT)
 
-
+void
+xfce_workspaces_helper_disable_wm_check(void)
+{
+    global_disable_wm_check = TRUE;
+}
 
 static void
 xfce_workspaces_helper_class_init(XfceWorkspacesHelperClass *klass)
@@ -476,7 +480,7 @@ xfce_workspaces_helper_set_names (XfceWorkspacesHelper *helper,
     guint       i;
     gchar     **atom_names;
 
-    if (!disable_wm_check)
+    if (!disable_wm_check && !global_disable_wm_check)
     {
         /* setup data for wm checking */
         wfwm = g_slice_new0 (WaitForWM);

--- a/xfsettingsd/workspaces.h
+++ b/xfsettingsd/workspaces.h
@@ -30,6 +30,7 @@ typedef struct _XfceWorkspacesHelper       XfceWorkspacesHelper;
 typedef struct _XfceWorkspacesHelperClass  XfceWorkspacesHelperClass;
 
 GType xfce_workspaces_helper_get_type(void) G_GNUC_CONST;
+void xfce_workspaces_helper_disable_wm_check(void);
 
 G_END_DECLS
 


### PR DESCRIPTION
Both xfdesktop and xfce4-panel have a --disable-wm-check command line option, presumably to allow xfce4 to be used with an alternate window manager (e.g. fluxbox) that does not use the same hints (ownership of the WM_S0, WM_S1, etc. selections) to register its operation that xfwm4 uses. However, xfsettingsd still waits for these hints during session startup. This pull request adds a --disable-wm-check option to not wait for these window manager hints, to make it consistent with the other xfce4 components and to allow a full session startup with an alternate window manager but without waiting for the check to time out.